### PR TITLE
fix(other): 带参选项卡表现异常

### DIFF
--- a/src/layout/components/AppMain.vue
+++ b/src/layout/components/AppMain.vue
@@ -45,9 +45,9 @@ export default defineComponent({
       if (currentIndex.value === tabName) {
         if (tabsOption.value && tabsOption.value.length) {
           store.commit('tabModule/SET_TAB', tabsOption.value[tabsOption.value.length - 1].route)
-          router.replace({ path: currentIndex.value })
+          router.replace(currentIndex.value)
         } else {
-          router.replace({ path: '/' })
+          router.replace('/')
         }
       }
     }
@@ -57,7 +57,7 @@ export default defineComponent({
     const clickTab = (tabName: { paneName: string }) => {
       // eslint-disable-next-line no-console
       store.commit('tabModule/SET_TAB', tabName.paneName)
-      router.replace({ path: currentIndex.value })
+      router.replace(currentIndex.value)
     }
     return {
       tabsOption,


### PR DESCRIPTION
## 问题复现：
1. 登录后，打开[https://geekqiaqia.github.io/vue3.0-template-admin/#/zip/exportZip?a=1](https://geekqiaqia.github.io/vue3.0-template-admin/#/zip/exportZip?a=1)
2. 点击当前活动选项卡

## 表现：
弹出新的同名选项卡，原选项卡参数丢失

## 原因：
`router.replace`API使用有误
参考官方文档https://router.vuejs.org/zh/api/#router-replace